### PR TITLE
Handle rebase usecase

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -142,6 +142,41 @@ async function getSteps() {
 }
 
 /**
+ * Merge previous and current steps. All previous explain will be kept.
+ * If any step is rebased out, it will be marked outdated.
+ */
+function mergeSteps(prevSteps, currentSteps) {
+  // Mark steps not included in latest steps as outdated.
+  prevSteps.forEach((prevStep) => {
+    if (!currentSteps.find(step => step.commit === prevStep.commit)) {
+      prevStep.outdated = true; /* eslint no-param-reassign: "off"  */
+    }
+  });
+
+  let [i, j] = [0, 0];
+  const mergedSteps = [];
+
+  while (i < prevSteps.length || j < currentSteps.length) {
+    if (i >= prevSteps.length) {
+      mergedSteps.push(currentSteps[j]);
+      j += 1;
+    } else if (j >= currentSteps.length || prevSteps[i].outdated) {
+      mergedSteps.push(prevSteps[i]);
+      i += 1;
+    } else if (prevSteps[i].commit === currentSteps[j].commit) {
+      mergedSteps.push(prevSteps[i]);
+      i += 1;
+      j += 1;
+    } else {
+      mergedSteps.push(currentSteps[j]);
+      j += 1;
+    }
+  }
+
+  return mergedSteps;
+}
+
+/**
  * Append .tuture rule to gitignore.
  * If it's already ignored, do nothing.
  * If .gitignore doesn't exist, create one and add the rule.
@@ -218,17 +253,9 @@ async function reloadTuture() {
   }
 
   const tuture = loadTuture();
-
   const currentSteps = await getSteps();
-  currentSteps.forEach((currentStep, index) => {
-    tuture.steps.forEach((step) => {
-      if (currentStep.commit === step.commit) {
-        currentSteps[index] = step;
-      }
-    });
-  });
+  tuture.steps = mergeSteps(tuture.steps, currentSteps);
 
-  tuture.steps = currentSteps;
   fs.writeFileSync('tuture.yml', yaml.safeDump(tuture));
   signale.success('Reload complete!');
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,6 +252,12 @@ async function reloadTuture() {
     errAndExit('Git is not installed on your machine!');
   }
 
+  if (!fs.existsSync(path.join(tutureRoot, 'diff.json'))) {
+    if (!fs.existsSync(tutureRoot)) {
+      fs.mkdirSync(tutureRoot);
+    }
+  }
+
   const tuture = loadTuture();
   const currentSteps = await getSteps();
   tuture.steps = mergeSteps(tuture.steps, currentSteps);
@@ -275,12 +281,7 @@ async function startTuture() {
   // Check for tuture.yml syntax.
   loadTuture();
 
-  if (!fs.existsSync(path.join(tutureRoot, 'diff.json'))) {
-    if (!fs.existsSync(tutureRoot)) {
-      fs.mkdirSync(tutureRoot);
-    }
-    await reloadTuture();
-  }
+  await reloadTuture();
 
   signale.success('Your tutorial is now served on http://localhost:3000.');
   cp.spawnSync('tuture-server');


### PR DESCRIPTION
Here is what this PR will achieve.

Suppose `L` is `steps` from current **tuture.yml**, and `R` is `steps` from latest git logs. Note that `L` has `explain` for each step while `R` doesn't, so if one `step` is present in both, we will opt for the one in `L`.

Now Tuture will make sure things below happen when `reload` is invoked whether automatically or manually:

- Add `step`s in `R` but not in `L` to `L`
- Mark `step`s in `L` but not in `R` as **outdated**
- Take care of the order of commits

The first two tasks are quite easy, so let me elaborate on the last one. Consider following situations:

1. `git commit`

```
L: 1, 2
R: 1, 2, 3
=> L1, L2, R3
```

`L: 1, 2` means `L` has commits `1` and `2`, `R: 1, 2, 3` means `R` has commits `1`, `2` and `3`, so merged commits would be `L1` (picked from `1` in `L`), `L2` and `R3`.

2. `git commit —amend`

```
L: 1, 2
R: 1, 3
=> L1, L2(outdated), R3
```

3. `git rebase` to squash

```
L: 1, 2, 3
R: 1, 4
=> L1, L2(outdated), L3(outdated), R4
```

4. `git rebase` to replace

```
L: 1, 2, 3
R: 1, 4, 3
=> L1, L2(oudated), R4, L3
```

5. `git rebase` to edit

```
L: 1, 2, 3
R: 1, 4, 5, 3
=> L1, L2(outdated), R4, R5, L3
```

6. totally different

```
L: 1, 2
R: 3, 4
=> L1(outdated), L2(oudated), R3, R4
```

